### PR TITLE
delete image name in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
 
   web: &web
     build: .
-    image: app:1.0.0
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
docker-compose.ymlの中にimageを指定しているのを一旦止める。

違うプロジェクトとimage名が重なって事故ったのが理由。

もうちょっと使い道を考える。